### PR TITLE
Update cpu_cholesky.cpp

### DIFF
--- a/Hardware_Accelerators/Introduction/03-Algorithm_Acceleration/docs/cpu_src/cpu_cholesky.cpp
+++ b/Hardware_Accelerators/Introduction/03-Algorithm_Acceleration/docs/cpu_src/cpu_cholesky.cpp
@@ -20,7 +20,8 @@
 
 void cpu_cholesky(int diagSize, double *matrixA) {
 
-   double dataA[MAXN][MAXN];
+   // double dataA[MAXN][MAXN];
+   double dataA[diagSize][diagSize];
 
    for(int i = 0; i < diagSize; i++){
       for (int j = 0; j < diagSize; j++) {


### PR DESCRIPTION
If we initialize the matrix to be `MAXN` by `MAXN` (which is not necessary when `diagSize` is smaller), the program will constantly run into Seg Fault when the system does not have enough stack memory.